### PR TITLE
Update input type for getPathBBox

### DIFF
--- a/src/util/getPathBBox.ts
+++ b/src/util/getPathBBox.ts
@@ -8,7 +8,7 @@ import pathLengthFactory from './pathLengthFactory';
  * @param path the shape `pathArray`
  * @returns the length of the cubic-bezier segment
  */
-const getPathBBox = (path?: PathArray): PathBBox => {
+const getPathBBox = (path?: PathArray | string): PathBBox => {
   if (!path) {
     return {
       x: 0,


### PR DESCRIPTION
This function accepts the same input as `pathLengthFactory` - a PathArray or string.

Currently, passing a string causes a TS error but produces the expected output.