### PR TITLE
Fix spells

### DIFF
--- a/docs/convert.html
+++ b/docs/convert.html
@@ -33,7 +33,7 @@
     </div>
     <div class="col p-0">
       <p class="text-right">
-        <a href="https://github.com/thednp/svg-path-commander">Github</a> | 
+        <a href="https://github.com/thednp/svg-path-commander">GitHub</a> |
         <a href="https://www.npmjs.com/package/svg-path-commander">npm</a> |
         <a href="https://www.jsdelivr.com/package/npm/svg-path-commander">cdn</a>
       </p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -32,7 +32,7 @@
     </div>
     <div class="col p-0">
       <p class="text-right">
-        <a href="https://github.com/thednp/svg-path-commander">Github</a> | 
+        <a href="https://github.com/thednp/svg-path-commander">GitHub</a> |
         <a href="https://www.npmjs.com/package/svg-path-commander">npm</a> |
         <a href="https://www.jsdelivr.com/package/npm/svg-path-commander">cdn</a>
       </p>
@@ -112,7 +112,7 @@
   <div class="row m-0 copy">
     <div class="col p-0" style="min-width: 57%;">
       <p>
-        <a href="https://github.com/thednp/svg-path-commander">Github</a> | 
+        <a href="https://github.com/thednp/svg-path-commander">GitHub</a> |
         <a href="https://www.npmjs.com/package/svg-path-commander">npm</a> |
         <a href="https://www.jsdelivr.com/package/npm/svg-path-commander">cdn</a>
       </p>


### PR DESCRIPTION
Fixes the spell of GitHub. It's a registered trademark. We should keep the spelling always correct.